### PR TITLE
Upgrade 'kexec' to support Node.js 4+

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "system"
   ],
   "optionalDependencies": {
-    "kexec": "^1.2.0"
+    "kexec": "^3.0.0"
   },
   "devDependencies": {},
   "dependencies": {


### PR DESCRIPTION
I've only upgraded to 2.0.2 rather than 3.0.0 in case continued Node.js 0.10 support is still desirable.
